### PR TITLE
fix(.travis.yml): Remove `--use-mirrors` option in `pip install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 # command to install dependencies
 install: 
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
   - pip install coveralls
 
 # command to run tests


### PR DESCRIPTION
`pip` has remove `--use-mirrors` option. https://github.com/pypa/pip/blob/master/CHANGES.txt#L372-L375

@tonyseek , Please review.