### PR TITLE
Fix issues #36 and #38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ nosetests.xml
 
 # IDE
 .vscode
+.venv

--- a/flask_rbac/__init__.py
+++ b/flask_rbac/__init__.py
@@ -178,6 +178,9 @@ class RBAC(object):
 
         app.before_request(self._authenticate)
 
+    def _check_setup_finished(self, f_name: str) -> None:
+        pass
+
     def as_role_model(self, model_cls):
         """A decorator to set custom model or role.
 
@@ -247,7 +250,6 @@ class RBAC(object):
         :param endpoint: The application endpoint.
         :param user: user who you need to check. Current user by default.
         """
-        app = self.get_app()
         _user = user or self._user_loader()
         if not hasattr(_user, 'get_roles'):
             roles = [anonymous]
@@ -282,6 +284,7 @@ class RBAC(object):
             resource = [endpoint or view_func.__name__]
             for r, m, v in itertools.product(roles, _methods, resource):
                 self.before_acl['allow'].append((r, m, v, with_children))
+
             return view_func
         return decorator
 
@@ -308,6 +311,7 @@ class RBAC(object):
             resource = [endpoint or view_func.__name__]
             for r, m, v in itertools.product(roles, _methods, resource):
                 self.before_acl['deny'].append((r, m, v, with_children))
+
             return view_func
         return decorator
 

--- a/flask_rbac/__init__.py
+++ b/flask_rbac/__init__.py
@@ -13,11 +13,6 @@ from flask import request, abort, current_app
 from flask.sansio.scaffold import setupmethod
 
 try:
-    from flask import _app_ctx_stack
-except ImportError:
-    _app_ctx_stack = None
-
-try:
     from flask_login import (current_user,
                              AnonymousUserMixin as anonymous_model)
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Flask==1.1.2
-Flask-Login==0.5.0
+Flask==3.0.2
+Flask-Login==0.6.3


### PR DESCRIPTION
Hello, I have corrected a few problems related to the new version of flask.

I updated the issues #36 and #38 related to deprecated methods of flask such as the `_request_ctx_stack` and `before_first_request`.

For the `_request_ctx_stack` and `_app_ctx_stack`, i replaced it by removing old imports and import `current_app` from flask and update the `get_app` method in consequence by only returning the current_app if it's not None.

For the `before_first_request`, i remove the concerned line and add the `@setupmethod` decorator and a `_check_setup_finished` method to RBAC class.

This is my first PR on an open-source project, please tell me if i do things wrong :smile: 